### PR TITLE
hotfix: Ajustando criação automática de Niveis de Acesso

### DIFF
--- a/-ms-usuario/src/main/resources/data.sql
+++ b/-ms-usuario/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+ALTER TABLE nivel_acesso AUTO_INCREMENT=0;
+
+INSERT IGNORE INTO nivel_acesso (nivelacesso_cod, nivelacesso_nome) VALUES
+(0, "Administrador"),
+(1, "Gestor"),
+(2, "Funcionário");

--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,7 @@ bin/
 Thumbs.db
 
 # Database files
-*.h2.db
-*.mv.db
-*.sql
+
 
 # Docker
 docker-compose.override.yml


### PR DESCRIPTION
# | hotfix: Ajustando criação automática de Niveis de Acesso | #

### O que foi feito: ###
- Adição do data.sql que cria automáticamente os campos

### Passos para testar: ###
1. Rode o projeto
2. Verifique se foi criado automaticamente 3 linhas na tabela de nível de acesso no banco de dados

### Checklist 
- [ x ] Atualizado com a develop
- [ x ] Dentro dos critérios de aceitação
- [ x ] Adicionado novas dependências
- [ x ] Código limpo e 
- [ x ] Dentro dos padrões de Projeto