### PR TITLE
hotfix/ms-ponto-jobcron

### DIFF
--- a/-ms-ponto/src/main/java/com/msponto/ms_ponto/modelo/VerificadorDiaTrabalhado.java
+++ b/-ms-ponto/src/main/java/com/msponto/ms_ponto/modelo/VerificadorDiaTrabalhado.java
@@ -11,15 +11,24 @@ import com.msponto.ms_ponto.dto.UsuarioDTO;
 
 public class VerificadorDiaTrabalhado {
 
-    public Boolean verificar(UsuarioDTO usuario, LocalDate dataAtual){
+    public Boolean verificar(UsuarioDTO usuario, LocalDate dataAtual) {
         JornadaDTO jornada = usuario.getJornada();
+    
+        if (jornada == null || jornada.getJornada_diasSemana() == null) {
+            return false;
+        }
+    
         DayOfWeek diaDaSemanaAtual = dataAtual.getDayOfWeek();
-
         List<String> diasSemana = Arrays.asList("SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY");
-        
+    
         Integer posicao = diasSemana.indexOf(diaDaSemanaAtual.toString());
-
-        Boolean diaAtualNaJornada = jornada.getJornada_diasSemana().get(posicao);
-        return diaAtualNaJornada;
+    
+        // Verifica se a posição é válida
+        if (posicao >= 0 && posicao < jornada.getJornada_diasSemana().size()) {
+            Boolean diaAtualNaJornada = jornada.getJornada_diasSemana().get(posicao);
+            return diaAtualNaJornada;
+        }
+    
+        return false;
     }
 }

--- a/-ms-ponto/src/main/java/com/msponto/ms_ponto/servico/HorasServico.java
+++ b/-ms-ponto/src/main/java/com/msponto/ms_ponto/servico/HorasServico.java
@@ -37,7 +37,19 @@ public class HorasServico {
     
     public Horas getUsuarioHorasByDate(Long usuario_cod, LocalDate horas_data){
         List<Horas> usuario_horas = horas_repo.findByUsuarioCodAndHorasData(usuario_cod, horas_data);
+        
+        if (usuario_horas.isEmpty()) {
+            return null;
+        }
+    
         return usuario_horas.get(0);
+    }
+
+    public Optional<Horas> getOptionalUsuarioHorasByDate(Long usuario_cod, LocalDate horas_data) {
+        List<Horas> usuario_horas = horas_repo.findByUsuarioCodAndHorasData(usuario_cod, horas_data);
+        
+        // Retorna um Optional vazio se a lista estiver vazia
+        return usuario_horas.isEmpty() ? Optional.empty() : Optional.of(usuario_horas.get(0));
     }
 
     public List<Horas> getAllHorasByDate(LocalDate horas_data){


### PR DESCRIPTION
# | Hotfix | #

### O que foi feito: ###
- Adicionado a verificação para conferir se o usuário não é administrador (não bate ponto) e se já não existe um registro de horas para aquele dia antes de criar o registro vazio de horas no bd, assim evitando erros.

### Passos para testar: ###
1. Rodar o -ms-usuario com os três tipos de usuários previamente cadastrados e englobando a situação em que um registro de horas já existe (basta rodar a aplicação mais de uma vez)

### Checklist 
- [x] Atualizado com a develop
- [x] Dentro dos critérios de aceitação
- [ ] Adicionado novas dependências
- [x] Código limpo e comentado
- [x] Dentro dos padrões de Projeto