### PR TITLE
hotfix: filtrar solicitações

### DIFF
--- a/-ms-ponto/src/main/java/com/msponto/ms_ponto/config/MySqlConfig.java
+++ b/-ms-ponto/src/main/java/com/msponto/ms_ponto/config/MySqlConfig.java
@@ -28,7 +28,7 @@ public class MySqlConfig {
         DataSourceBuilder<?> dataSourceBuilder = DataSourceBuilder.create();
             dataSourceBuilder.url("jdbc:mysql://localhost:3306/BOTPonto");
             dataSourceBuilder.username("root");
-            dataSourceBuilder.password("root");
+            dataSourceBuilder.password("fatec");
             return dataSourceBuilder.build();
     }
 

--- a/-ms-ponto/src/main/resources/application.properties
+++ b/-ms-ponto/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8082
 # Configuração do MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/BOTPonto
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=fatec
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/-ms-solicitacao/src/main/java/com/ms/solicitacao/controller/SolicitacaoController.java
+++ b/-ms-solicitacao/src/main/java/com/ms/solicitacao/controller/SolicitacaoController.java
@@ -41,6 +41,16 @@ public class SolicitacaoController {
 		return solicitacaoService.findAll();
 	}
 	
+	@GetMapping("/usuario/{id}")
+	private List<Solicitacao> findAllByUsuario(@PathVariable long id) {
+		return solicitacaoService.findAllByUsuario(id);
+	}
+	
+	@GetMapping("/setor/{setorCod}")
+	private List<Solicitacao> findAllBySetor(@PathVariable long setorCod){
+		return solicitacaoService.findAllBySetor(setorCod);
+	}
+	
 	@GetMapping("/{id}")
 	private Solicitacao findById(@PathVariable long id) {
 		return solicitacaoService.findById(id);
@@ -52,6 +62,7 @@ public class SolicitacaoController {
 	    @RequestParam(value = "solicitacaoAnexo", required = false) MultipartFile solicitacaoAnexo
 	) {
 	    try {
+	    	solicitacaoJson = solicitacaoJson.replace('\u00A0', ' ').trim();
 	        Solicitacao solicitacao = objectMapper.readValue(solicitacaoJson, Solicitacao.class);
 
 	        if (solicitacaoAnexo != null && !solicitacaoAnexo.isEmpty()) {

--- a/-ms-solicitacao/src/main/java/com/ms/solicitacao/dto/UsuarioDTO.java
+++ b/-ms-solicitacao/src/main/java/com/ms/solicitacao/dto/UsuarioDTO.java
@@ -6,6 +6,8 @@ public class UsuarioDTO {
     private String usuario_cpf;
     private String usuario_email;
     private String usuario_cargo;
+    private int setorCod;
+    private int nivelAcesso_cod;
 
     // Getters and Setters
     public Long getUsuario_cod() {
@@ -28,7 +30,25 @@ public class UsuarioDTO {
         return usuario_cpf;
     }
 
-    public void setUsuario_cpf(String usuario_cpf) {
+    public int getSetorCod() {
+		return setorCod;
+	}
+
+	public void setSetorCod(int setorCod) {
+		this.setorCod = setorCod;
+	}
+
+
+
+	public int getNivelAcesso_cod() {
+		return nivelAcesso_cod;
+	}
+
+	public void setNivelAcesso_cod(int nivelAcesso_cod) {
+		this.nivelAcesso_cod = nivelAcesso_cod;
+	}
+
+	public void setUsuario_cpf(String usuario_cpf) {
         this.usuario_cpf = usuario_cpf;
     }
 

--- a/-ms-solicitacao/src/main/java/com/ms/solicitacao/model/Solicitacao.java
+++ b/-ms-solicitacao/src/main/java/com/ms/solicitacao/model/Solicitacao.java
@@ -46,11 +46,17 @@ public class Solicitacao {
     @Transient
     private String usuarioCargo;
     
+    @Transient
+    private int setorCod;
+    
+    @Transient
+    private int nivelAcesso_cod;
+    
     @ManyToOne
     @JoinColumn(name = "tipoSolicitacaoCod", nullable = false)
     private SolicitacaoTipo tipoSolicitacaoCod;
 
-	public long getSolicitacaoCod() {
+	public long getSolicitacaoCod() { 
 		return solicitacaoCod;
 	}
 
@@ -136,6 +142,22 @@ public class Solicitacao {
 
 	public void setSolicitacaoAnexoNome(String solicitacaoAnexoNome) {
 		this.solicitacaoAnexoNome = solicitacaoAnexoNome;
+	}
+
+	public int getSetorCod() {
+		return setorCod;
+	}
+
+	public void setSetorCod(int setorCod) {
+		this.setorCod = setorCod;
+	}
+
+	public int getNivelAcesso_cod() {
+		return nivelAcesso_cod;
+	}
+
+	public void setNivelAcesso_cod(int nivelAcesso_cod) {
+		this.nivelAcesso_cod = nivelAcesso_cod;
 	}
 
 }

--- a/-ms-solicitacao/src/main/java/com/ms/solicitacao/service/SolicitacaoService.java
+++ b/-ms-solicitacao/src/main/java/com/ms/solicitacao/service/SolicitacaoService.java
@@ -4,6 +4,7 @@ import com.ms.solicitacao.dto.UsuarioDTO;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,34 @@ public class SolicitacaoService {
             adicionarUsuarioInformacao(solicitacao);
         }
         return solicitacoes;
+    }
+    
+    public List<Solicitacao> findAllByUsuario(long usuarioId) {
+    	List<Solicitacao> solicitacoes = solicitacaoRepository.findAll();
+    	for (Solicitacao solicitacao : solicitacoes) {
+            adicionarUsuarioInformacao(solicitacao);
+        }
+    	List<Solicitacao> solicitacoesUsuario = solicitacoes.stream()
+    			.filter(solicitacao -> solicitacao.getUsuarioCod() == usuarioId)
+    			.collect(Collectors.toList());
+    	if (solicitacoesUsuario != null) {
+    		return solicitacoesUsuario;
+    	}
+    	return null;
+    }
+    
+    public List<Solicitacao> findAllBySetor(long setorCod) {
+    	List<Solicitacao> solicitacoes = solicitacaoRepository.findAll();
+    	for (Solicitacao solicitacao : solicitacoes) {
+            adicionarUsuarioInformacao(solicitacao);
+        }
+    	List<Solicitacao> solicitacoesSetor = solicitacoes.stream()
+    			.filter(solicitacao -> solicitacao.getSetorCod() == setorCod)
+    			.collect(Collectors.toList());
+    	if (solicitacoesSetor != null) {
+    		return solicitacoesSetor;
+    	}
+    	return null;
     }
 
     public Solicitacao findById(long id) {
@@ -86,6 +115,8 @@ public class SolicitacaoService {
 	            if (usuario != null) {
 	                solicitacao.setUsuarioNome(usuario.getUsuario_nome());
 	                solicitacao.setUsuarioCargo(usuario.getUsuario_cargo());
+	                solicitacao.setNivelAcesso_cod(usuario.getNivelAcesso_cod());
+	                solicitacao.setSetorCod(usuario.getSetorCod());
 	            }
 	        } catch (org.springframework.web.client.HttpClientErrorException.NotFound e) {
 	            System.err.println("Usuário com ID " + solicitacao.getUsuarioCod() + " não encontrado.");

--- a/-ms-solicitacao/src/main/resources/application.properties
+++ b/-ms-solicitacao/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=8083
 
 spring.datasource.url=jdbc:mysql://localhost:3306/BOTSolicitacoes?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=fatec
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuracao do JPA

--- a/-ms-usuario/src/main/resources/application.properties
+++ b/-ms-usuario/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.port=8081
 spring.datasource.url=jdbc:mysql://localhost:3306/BOTUsuario
 spring.datasource.username=root
 #spring.datasource.password=aluno
-spring.datasource.password=root
+spring.datasource.password=fatec
 spring.jpa.show-sql=true
 
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
# | Ajustes endpoints  | #

### O que foi feito: ###
- Criado endpoints para filtrar solicitações por usuário e por setor, para que quando o usuário for funcionário, requisita apenas as suas solicitações, quando for gestor, requisita solicitações de apenas seu setor 

### Passos para testar: ###
1. Para requisitar solicitações de um usuário específico
GET /solicitacao/usuario/{id}

2. Para requisitar solicitações de um setor específico 
GET /solicitacao/setor/{setorCod}

### Checklist 
- [x] Atualizado com a develop
- [x] Dentro dos critérios de aceitação
- [x] Adicionado novas dependências
- [x] Código limpo e 
- [x] Dentro dos padrões de Projeto