### PR TITLE
hotfix: Ajustando relacionamento de setor para empresa

### DIFF
--- a/-ms-ponto/src/main/java/com/msponto/ms_ponto/repositorio/mysql/HorasRepositorio.java
+++ b/-ms-ponto/src/main/java/com/msponto/ms_ponto/repositorio/mysql/HorasRepositorio.java
@@ -4,9 +4,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.msponto.ms_ponto.entidade.mysql.Horas;
 
+@Repository
 public interface HorasRepositorio extends JpaRepository<Horas, Long>{
     List<Horas> findByUsuarioCod(Long usuarioCod);
     List<Horas> findByUsuarioCodAndHorasData(Long usuarioCod, LocalDate horasData);

--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Empresa.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Empresa.java
@@ -27,7 +27,15 @@ public class Empresa {
     @Column
     private String empRazaoSocial;
 
-    @Column
+    public List<Setor> getSetores() {
+		return setores;
+	}
+
+	public void setSetores(List<Setor> setores) {
+		this.setores = setores;
+	}
+
+	@Column
     private String empCep;
 
     @Column
@@ -41,6 +49,9 @@ public class Empresa {
 
     @OneToMany(mappedBy = "empresa")
     private List<Usuario> usuarios;
+
+    @OneToMany(mappedBy = "empresa")
+    private List<Setor> setores;
 
     // Getters and Setters
 

--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Setor.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Setor.java
@@ -2,11 +2,16 @@ package com.fatec.ms_usuario.entidade;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
 @Entity
@@ -18,6 +23,13 @@ public class Setor {
 
     @Column
     private String setorNome;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "empCod", referencedColumnName = "empCod", insertable = false, updatable = false)
+	@JsonIgnore
+	private Empresa empresa;
+
+	private Long empCod; // Foreign key field for Empresa	
 
     @OneToMany(mappedBy = "setor")
     private List<Usuario> usuarios;
@@ -32,7 +44,23 @@ public class Setor {
         this.setorCod = setorCod;
     }
 
-    public String getSetorNome() {
+    public Empresa getEmpresa() {
+		return empresa;
+	}
+
+	public void setEmpresa(Empresa empresa) {
+		this.empresa = empresa;
+	}
+
+	public Long getEmpCod() {
+		return empCod;
+	}
+
+	public void setEmpCod(Long empCod) {
+		this.empCod = empCod;
+	}
+
+	public String getSetorNome() {
         return setorNome;
     }
 


### PR DESCRIPTION
### O que foi feito: ###
- Ajuste do relacionamento dentre a entidade "Setor" com "Empresa" conforme consta no modelo relacional do banco de dados. Agora setores pertencem a necessariamente uma empresa, e uma empresa aloja diversos ou nenhum setor.

### Passos para testar: ###
1.  Acesse a rota /empresa com o método POST e cadastre uma empresa enviando um json no corpo da requisição nesse modelo:
{
  "empNome": "Teste Social",
  "empCnpj": "52125919000130",
  "empRazaoSocial": "TESTES",
  "empCep": "12412200",
  "empCidade": "Pindamonhangaba",
  "empEstado": "São Paulo",
  "empEndereco": "Rua Jannarte Moutinho Ribeiro, 160"
}
2. Acesse a rota /setor com o método POST e cadastre uma empresa enviando um json no corpo da requisição nesse modelo:
{
  "setorNome": "ADM",
  "empCod": 1
}
3. Acesse a rota /empresa com o método GET e verifique se o setor cadastrado consta na resposta da aplicação no objeto da empresa cujo o setor foi atrelado com o parametro "empCod"

### Checklist 
- [ x ] Atualizado com a develop
- [ x ] Dentro dos critérios de aceitação
- [x] Adicionado novas dependências
- [ x ] Código limpo e 
- [ x ] Dentro dos padrões de Projeto