### PR TITLE
hotfix: Adicionado usuario_status

### DIFF
--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/controle/SetorControle.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/controle/SetorControle.java
@@ -38,6 +38,16 @@ public class SetorControle {
         return new ResponseEntity<>(savedSetor, HttpStatus.CREATED);
     }
 
+    @GetMapping("/empresa/{empCod}")
+    public ResponseEntity<List<Setor>> obterSetorPorEmpresaId(@PathVariable Long empCod) {
+        List<Setor> setores = repositorio.findAll();
+        setores.removeIf(setor -> (setor.getEmpCod() != empCod));
+
+        if(setores.isEmpty())
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(setores, HttpStatus.OK);
+    }
+
     @GetMapping("/{setorCod}")
     public ResponseEntity<Setor> obterSetorPorId(@PathVariable Long setorCod) {
         return repositorio.findById(setorCod)

--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/controle/UsuarioControle.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/controle/UsuarioControle.java
@@ -81,6 +81,7 @@ public class UsuarioControle {
         novoUsuario.setUsuarioEmail(novoDTO.getUsuarioEmail());
         novoUsuario.setUsuario_DataNascimento(novoDTO.getUsuario_DataNascimento());
         novoUsuario.setUsuario_cargo(novoDTO.getUsuario_cargo());
+        novoUsuario.setUsuario_status(novoDTO.getUsuario_status());
 
         novoUsuario.setEmpCod(novoDTO.getEmpCod());
         novoUsuario.setSetorCod(novoDTO.getSetorCod());
@@ -138,6 +139,8 @@ public class UsuarioControle {
         alvo.setUsuario_DataNascimento(usuario.getUsuario_DataNascimento());
         alvo.setEmpCod(usuario.getEmpCod());
         alvo.setSetorCod(usuario.getSetorCod());
+        alvo.setNivelAcesso_cod(usuario.getNivelAcesso_cod());
+        alvo.setUsuario_status(usuario.getUsuario_status());
 
         repositorio.save(alvo);
         return ResponseEntity.ok("Usuário atualizado com sucesso.");

--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/dto/UsuarioDTO.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/dto/UsuarioDTO.java
@@ -12,6 +12,7 @@ public class UsuarioDTO {
     private LocalTime horarioSaida; // Alterando de Time para LocalTime
 
     private Boolean horarioFlexivel;
+    private Boolean usuario_status;
     private Long nivelAcesso_cod;
     private Long setorCod;
     private String usuarioEmail;
@@ -97,6 +98,12 @@ public class UsuarioDTO {
     }
     public void setUsuario_cargo(String usuario_cargo) {
         this.usuario_cargo = usuario_cargo;
+    }
+    public Boolean getUsuario_status() {
+        return usuario_status;
+    }
+    public void setUsuario_status(Boolean usuario_status) {
+        this.usuario_status = usuario_status;
     }
     public String getUsuario_cpf() {
         return usuario_cpf;

--- a/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Usuario.java
+++ b/-ms-usuario/src/main/java/com/fatec/ms_usuario/entidade/Usuario.java
@@ -61,6 +61,9 @@ public class Usuario {
 	@Column
 	private String usuario_cargo;
 
+	@Column
+	private Boolean usuario_status;
+
 	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "empCod", referencedColumnName = "empCod", insertable = false, updatable = false)
 	@JsonIgnore
@@ -218,6 +221,14 @@ public class Usuario {
 		this.usuario_cargo = usuario_cargo;
 	}
 
+	public Boolean getUsuario_status() {
+		return usuario_status;
+	}
+	
+	public void setUsuario_status(Boolean usuario_status) {
+		this.usuario_status = usuario_status;
+	}
+	
 	public NivelAcesso getNivelAcesso(){
 		return nivelAcesso;
 	}


### PR DESCRIPTION
# | Fazer tela de editar Colaborador | (SKF-84) | #

### O que foi feito: ###
- Adaptação para "usuario_status" para Ativo e Inativo.

### Passos para testar: ###
Recomendado a branch de [Frontend da SKF-84](https://github.com/SkyFlyTeam/BeeOnTime-frontend/pull/104) para testar. Num serviço MySQL ou de API (como Insomnia), deve aparecer ter a nova coluna para o usuário. Além do mais, ao cadastrar novo Colaborador, deve automaticamente considerar novo cadastro como Ativo.

### Checklist 
- [ ] Atualizado com a develop
- [ ] Dentro dos critérios de aceitação
- [ ] Adicionado novas dependências
- [ ] Código limpo e 
- [ ] Dentro dos padrões de Projeto